### PR TITLE
Fix typo and remove Python pip install when not required

### DIFF
--- a/boss2_oled_p3/install_boss2_oled.sh
+++ b/boss2_oled_p3/install_boss2_oled.sh
@@ -122,10 +122,9 @@ then
                 echo "******************************************"
                 sudo apt-get -y update
                 sudo apt-get -y install python3-rpi.gpio
-                sudo apt-get -y install python3-pip
                 sudo apt-get -y install python3-smbus
                 sudo apt-get -y install python3-pil
-		udo apt-get -y install raspi-config
+		sudo apt-get -y install raspi-config
                 sudo apt-get -y install i2c-tools
                 sleep 2
                 sudo raspi-config nonint do_i2c 0
@@ -158,7 +157,6 @@ then
 		echo "******************************************"
 		sudo apt-get -y update 
                 sudo apt-get -y install python3-rpi.gpio
-		sudo apt-get -y install python3-pip
 		sudo apt-get -y install python3-smbus 
 		sudo apt-get -y install python3-pil 
 		#sudo apt-get -y install python-netifaces 


### PR DESCRIPTION
On max2play and DietPi systems, where the "python3-rpi.gpio" package is available in APT repositories, pip ("python3-pip") is not used and hence does not need to be installed.

I see the archive needs to be updated with this changed file, but for now to review first I only changed it in the unpacked file. I'll add it in case to the archive as well.